### PR TITLE
Add MOSS LangGraph Integration

### DIFF
--- a/README.md
+++ b/README.md
@@ -1170,7 +1170,7 @@ Access the official LangSmith platform documentation:
 | [Azzedde/brainstormers](https://github.com/Azzedde/brainstormers) | Curated chains for structured brainstorming | ![GitHub stars](https://img.shields.io/github/stars/Azzedde/brainstormers?style=social) |
 | [zamalali/langchain-code](https://github.com/zamalali/langchain-code) | Multi-LLM CLI tool with ReAct & Deep modes for code analysis, feature implementation, and bug fixing | ![GitHub stars](https://img.shields.io/github/stars/zamalali/langchain-code?style=social) |
 | [Mediaeater/swarm.at](https://github.com/Mediaeater/swarm-at-ledger) | Settlement protocol that hash-chains every LangGraph node execution into an immutable audit ledger with trust-tiered agent identities | ![GitHub stars](https://img.shields.io/github/stars/Mediaeater/swarm.at?style=social) |
-| [mosscomputing/moss-langgraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions | ![GitHub stars](https://img.shields.io/github/stars/mosscomputing/moss-langgraph?style=social) |
+| [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
 
 <div align="center">
 


### PR DESCRIPTION
## What is MOSS LangGraph?

moss-langgraph provides cryptographic signing for LangGraph workflows using ML-DSA-44 post-quantum signatures.

## Why it belongs here

- Sign node outputs and state transitions
- Tamper-proof audit trails for LangGraph applications
- Offline verification without API calls
- Post-quantum secure (NIST FIPS 204)

## Installation

```bash
pip install moss-langgraph
```

## Links

- PyPI: https://pypi.org/project/moss-langgraph/
- Website: https://mosscomputing.com