### PR TITLE
Adding pic-standard protocol (and) under new category

### DIFF
--- a/README.md
+++ b/README.md
@@ -1283,6 +1283,21 @@ Access the official LangSmith platform documentation:
 
 <div align="center">
 
+## 🌍 Security & Governance
+
+</div>
+
+*Action verification, provenance tracking, fail-closed mechanisms, prompt injection protection*
+
+| Project | Description | GitHub Stars |
+|---|---|---|
+| [pic-standard](https://github.com/madeinpluto/pic-standard) | Local-first protocol for provenance & intent verification before agent actions (fail-closed, verifiable evidence). | ![GitHub stars](https://img.shields.io/github/stars/madeinpluto/pic-standard?style=social) |
+
+
+
+
+<div align="center">
+
 ## 🌍 Sustainability
 
 </div>


### PR DESCRIPTION
Adding a new "Security & Governance" category:

Then adding:
- [PIC Standard](https://github.com/madeinplutofabio/pic-standard) – Local-first protocol for provenance & intent verification before agent actions (fail-closed, verifiable evidence).


As suggested at https://github.com/langchain-ai/langgraph/issues/6684