### PR TITLE
Add defi-mcp to Finance & Fintech section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1191,6 +1191,7 @@ Access the official LangSmith platform documentation:
 | [sagar-n/deepagents](https://github.com/sagar-n/deepagents) | Stock research assistant with specialized analysis agents | ![GitHub stars](https://img.shields.io/github/stars/sagar-n/deepagents?style=social) |
 | [AKMessi/AI-IPO-Analyst](https://github.com/AKMessi/AI-IPO-Analyst) | IPO analysis agent with PDF parsing and market data enrichment | ![GitHub stars](https://img.shields.io/github/stars/AKMessi/AI-IPO-Analyst?style=social) |
 | [johnsonhk88/AI-Bank-Statement-Document-Automation-By-LLM-And-Personal-Finanical-Analysis-Prediction](https://github.com/johnsonhk88/AI-Bank-Statement-Document-Automation-By-LLM-And-Personal-Finanical-Analysis-Prediction) | Bank statement parsing + personal finance analysis with multi-agent workflow | ![GitHub stars](https://img.shields.io/github/stars/johnsonhk88/AI-Bank-Statement-Document-Automation-By-LLM-And-Personal-Finanical-Analysis-Prediction?style=social) |
+| [OzorOwn/defi-mcp](https://github.com/OzorOwn/defi-mcp) | DeFi MCP server with 12 tools: real-time crypto prices, multi-chain wallet balances (9 chains), DEX quotes via Jupiter and Li.Fi, and token search across 275+ assets | ![GitHub stars](https://img.shields.io/github/stars/OzorOwn/defi-mcp?style=social) |
 
 <div align="center">
 


### PR DESCRIPTION
Adds [defi-mcp](https://github.com/OzorOwn/defi-mcp) to the Finance & Fintech community projects section.

**defi-mcp** is an MCP server with 12 tools for DeFi and crypto data:
- Real-time crypto prices (275+ assets)
- Multi-chain wallet balances (Ethereum, Solana, Polygon, Arbitrum, Optimism, BSC, Avalanche, Base, Fantom)
- DEX quotes via Jupiter (Solana) and Li.Fi (EVM cross-chain)
- Token search and discovery

It integrates with LangChain agents via MCP adapters, enabling financial analysis and DeFi research workflows.