### PR TITLE
Add Headless Oracle to Security & Governance

### DIFF
--- a/README.md
+++ b/README.md
@@ -1293,6 +1293,7 @@ Access the official LangSmith platform documentation:
 | Project | Description | GitHub Stars |
 |---|---|---|
 | [pic-standard](https://github.com/madeinpluto/pic-standard) | Local-first protocol for provenance & intent verification before agent actions (fail-closed, verifiable evidence). | ![GitHub stars](https://img.shields.io/github/stars/madeinpluto/pic-standard?style=social) |
+| [Headless Oracle](https://headlessoracle.com/v5/demo?mic=XNYS) | Fail-closed market status MCP server that acts as a deterministic circuit breaker to prevent durable execution loops when traditional exchanges are closed. | ![GitHub stars](https://img.shields.io/github/stars/LembaGang/dst-exploit-demo?style=social) |
 
 
 

--- a/README.md
+++ b/README.md
@@ -1292,8 +1292,8 @@ Access the official LangSmith platform documentation:
 
 | Project | Description | GitHub Stars |
 |---|---|---|
+| [LembaGang/headless-oracle-v5](https://github.com/LembaGang/headless-oracle-v5) | Fail-closed market status MCP. Pauses stateful LangGraph agents from entering retry loops during closed markets or DST shifts. | ![GitHub stars](https://img.shields.io/github/stars/LembaGang/headless-oracle-v5?style=social) |
 | [pic-standard](https://github.com/madeinpluto/pic-standard) | Local-first protocol for provenance & intent verification before agent actions (fail-closed, verifiable evidence). | ![GitHub stars](https://img.shields.io/github/stars/madeinpluto/pic-standard?style=social) |
-| [Headless Oracle](https://headlessoracle.com/v5/demo?mic=XNYS) | Fail-closed market status MCP server that acts as a deterministic circuit breaker to prevent durable execution loops when traditional exchanges are closed. | ![GitHub stars](https://img.shields.io/github/stars/LembaGang/dst-exploit-demo?style=social) |
 
 
 


### PR DESCRIPTION
Adding Headless Oracle to the fail-closed mechanisms list. Noticed that stateful agents using durable execution get trapped in severe compute-burning retry loops when hitting closed traditional markets (like the upcoming Mar 8 DST shift). Built this fail-closed MCP to allow LangGraph router nodes to cleanly pause execution until the next opening bell.