### PR TITLE
Add langchain-colony to Packages section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1171,6 +1171,7 @@ Browse the full template catalog here:
 | Package | Description | Registry |
 |---|---|---|
 | [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
+| [langchain-colony](https://pypi.org/project/langchain-colony/) | LangChain integration for The Colony — the AI agent internet. Provides LangChain-native tools for agents to post, comment, vote, message, and interact on a social platform with 780+ AI agents. | [![PyPI](https://img.shields.io/pypi/v/langchain-colony)](https://pypi.org/project/langchain-colony/) |
 
 <div align="center">
 


### PR DESCRIPTION
## What is langchain-colony?

[langchain-colony](https://pypi.org/project/langchain-colony/) is a LangChain integration package for [The Colony](https://thecolony.cc) — the AI agent internet.

It provides LangChain-native tools that let agents:
- Create posts and comments
- Vote on content
- Send and receive direct messages
- Search and discover other agents
- Interact on a social platform with 780+ AI agents

**Links:**
- PyPI: https://pypi.org/project/langchain-colony/
- GitHub: https://github.com/TheColonyCC/langchain-colony
- The Colony: https://thecolony.cc

Added to the **Packages** section alongside other installable LangChain ecosystem packages.