### PR TITLE
Add hermesagent/langchain-hermes to Web Automation & Scraping

### DIFF
--- a/README.md
+++ b/README.md
@@ -1029,6 +1029,7 @@ Browse the full template catalog here:
 | [stanford-mast/blast](https://github.com/stanford-mast/blast) | High-performance serving engine for browser-augmented LLM applications with auto-scaling and OpenAI-compatible API | ![GitHub stars](https://img.shields.io/github/stars/stanford-mast/blast?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/stanford-mast/blast) |
 | [ScrapeGraphAI/scrapecraft](https://github.com/ScrapeGraphAI/scrapecraft) | Visual editor for building scraping workflows with LangGraph, bulk scraping, and live streaming | ![GitHub stars](https://img.shields.io/github/stars/ScrapeGraphAI/scrapecraft?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/ScrapeGraphAI/scrapecraft) |
 | [nickhawn/news-agent](https://github.com/nickhawn/news-agent) | News crawler that personalizes daily summaries with Tavily and memory | ![GitHub stars](https://img.shields.io/github/stars/nickhawn/news-agent?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/nickhawn/news-agent) |
+| [hermesagent/langchain-hermes](https://github.com/hermesagent/langchain-hermes) | LangChain tool that screenshots any URL and returns a base64 image for multimodal LLM analysis. No signup required for basic use. | ![GitHub stars](https://img.shields.io/github/stars/hermesagent/langchain-hermes?style=social)<br>![Last commit](https://img.shields.io/github/last-commit/hermesagent/langchain-hermes) |
 
 <div align="center">
 


### PR DESCRIPTION
## What this adds

**`hermesagent/langchain-hermes`** — LangChain tool wrapping the [Hermes Screenshot API](https://hermesforge.dev/api). Gives LangGraph agents visual web perception: screenshot any URL, return base64 image for multimodal LLM analysis.

**Why it fits here:**
- `HermesScreenshotTool` is a `BaseTool` subclass — drops directly into any LangChain/LangGraph agent
- Web Automation & Scraping section: screenshot = visual web observation, a key web automation primitive
- No signup required for basic use (rate-limited free tier)

**Checklist:**
- [x] Uses LangChain (`langchain_core.tools.BaseTool`)
- [x] Active maintenance
- [x] Description under 200 chars
- [x] Working GitHub link