### PR TITLE
Add Agent Memory Techniques to Examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1329,6 +1329,7 @@ No active community listings currently.
 | Name | Description |
 |---|---|
 | [RAG Techniques](https://github.com/NirDiamant/RAG_Techniques) | Several RAG implementations and step-by-step walkthroughs. |
+| [Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques) | 30 notebooks on agent memory: vector stores, knowledge graphs, episodic and semantic memory, Mem0, MemGPT/Letta, Zep, and Graphiti. |
 
 </details>
 


### PR DESCRIPTION
Adds [Agent Memory Techniques](https://github.com/NirDiamant/Agent_Memory_Techniques) to the Examples table — 30 runnable notebooks on agent memory (vector stores, knowledge graphs, episodic/semantic memory, Mem0, Letta/MemGPT, Zep, Graphiti). Complements the existing NirDiamant entries (GenAI Agents, RAG Techniques) already in this section. Matched the table format.