### PR TITLE
Add langgraph-tenancy to Packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -1069,6 +1069,7 @@ Browse the full template catalog here:
 |---|---|---|
 | [MOSS LangGraph](https://pypi.org/project/moss-langgraph/) | Cryptographic signing for LangGraph workflows. Add tamper-proof audit trails with ML-DSA-44 post-quantum signatures to node outputs and state transitions. | [![PyPI](https://img.shields.io/pypi/v/moss-langgraph)](https://pypi.org/project/moss-langgraph/) |
 | [langchain-colony](https://pypi.org/project/langchain-colony/) | LangChain integration for The Colony — the AI agent internet. Provides LangChain-native tools for agents to post, comment, vote, message, and interact on a social platform with 780+ AI agents. | [![PyPI](https://img.shields.io/pypi/v/langchain-colony)](https://pypi.org/project/langchain-colony/) |
+| [langgraph-tenancy](https://pypi.org/project/langgraph-tenancy/) | Tenant isolation for multi-tenant LangGraph deployments. Tenant-scoped checkpointer and store wrappers that physically prefix thread ids and namespaces, refuse unscoped access, and meter token usage per tenant. | [![PyPI](https://img.shields.io/pypi/v/langgraph-tenancy)](https://pypi.org/project/langgraph-tenancy/) |
 
 <div align="center">
 


### PR DESCRIPTION
Adds [langgraph-tenancy](https://github.com/ac12644/langgraph-tenancy) ([PyPI](https://pypi.org/project/langgraph-tenancy/)) to the Packages section.

Tenant isolation for multi-tenant LangGraph deployments: tenant-scoped `BaseCheckpointSaver`/`BaseStore` wrappers that physically prefix thread ids and store namespaces with a required tenant id, refuse unscoped access (e.g. `list(None)`), and extract per-tenant token usage from checkpoints. MIT licensed; adversarial isolation test suite runs against InMemorySaver and PostgresSaver in CI.

Row format matches the existing Packages table (PyPI badge included).